### PR TITLE
fix(raster): port _raster to COO fire storage

### DIFF
--- a/src/raster.jl
+++ b/src/raster.jl
@@ -168,26 +168,8 @@ function _raster(
     order = [],
 ) where {T<:Union{AbstractPopulation,AbstractStimulus}}
     !haskey(p.records, :fire) && @error "No fire record found in population $(p.name)"
-    fire = p.records[:fire]
-    x, y = Float32[], Float32[]
-    y0 = Int32[]
     interval = typeof(interval) <: AbstractRange ? interval[[1, end]] : interval
-    for i in eachindex(fire[:time])
-        t = fire[:time][i]
-        # which neurons to plot
-        for n in fire[:neurons][i]
-            if isnothing(interval) || (t > interval[1] && t < interval[2])
-                if !isempty(order)
-                    z = indexin(n, order)[1]
-                    isnothing(z) && continue
-                    push!(x, t)
-                    push!(y, z)
-                else
-                    push!(x, t)
-                    push!(y, n)
-                end
-            end
-        end
-    end
-    return x, y, y0
+    st = SNNModels.spiketimes(p; interval)
+    x, y = _raster(st, interval; order)
+    return x, y, Int32[]
 end


### PR DESCRIPTION
## Problem

`_raster(p::AbstractPopulation, ...)` read spike data directly from the legacy push!-based fire record layout:

```julia
for i in eachindex(fire[:time])       # Vector{Float32} — one entry per recorded timestep
    t = fire[:time][i]
    for n in fire[:neurons][i]        # Vector{Vector{Int}} — spiking neurons per timestep
```

SNNModels PR #71 (`fix/record-indexed-dense`) replaced this with pre-allocated flat COO buffers (`times_buf` / `neurons_buf`, one entry per spike). After that change `fire[:time]` and `fire[:neurons]` are always empty, so raster plots silently produced blank figures.

## Fix

Delegate to `SNNModels.spiketimes(p; interval)`, which dispatches on the fire storage format — COO for new data, legacy layout for data loaded from disk via `SNNload`. The result is passed to the existing `_raster(::Spiketimes, ...)` overload which already handles interval filtering and neuron reordering.

```julia
function _raster(p::T, interval=nothing; order=[]) where {T<:Union{AbstractPopulation,AbstractStimulus}}
    !haskey(p.records, :fire) && @error "No fire record found in population $(p.name)"
    interval = typeof(interval) <: AbstractRange ? interval[[1, end]] : interval
    st = SNNModels.spiketimes(p; interval)
    x, y = _raster(st, interval; order)
    return x, y, Int32[]
end
```

25-line manual loop → 3 lines. No API change for callers.

## Test

Verified manually before pushing:

```
spiketimes total: 1327
_raster  x=1327  y=1327
PASS
```

Run with:
```bash
julia --project=/path/to/network_models test_raster_coo.jl
```

## Dependency

Requires SNNModels.jl PR #71 to be merged first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)