### PR TITLE
Bump SNNModels compat to 1.8 (v0.2.7)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SNNPlots"
 uuid = "1906bf50-7128-11ef-3209-891d16f9be9f"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Alessio <alessio.quaresima@pasteur.fr>"]
 
 [deps]
@@ -29,7 +29,7 @@ Measures = "0.3"
 Parameters = "0.12"
 Plots = "1.40"
 Requires = "1.3.1"
-SNNModels = "1.5"
+SNNModels = "1.8"
 Statistics = "1.11"
 UnPack = "1.0"
 julia = "1.11"


### PR DESCRIPTION
## Summary
- Bump `SNNModels` compat bound from 1.5 to 1.8
- Patch version 0.2.6 → 0.2.7

@JuliaRegistrator register