### PR TITLE
version compatibility updates

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SNNPlots"
 uuid = "1906bf50-7128-11ef-3209-891d16f9be9f"
-version = "0.2.7"
+version = "0.2.8"
 authors = ["Alessio <alessio.quaresima@pasteur.fr>"]
 
 [deps]
@@ -32,4 +32,4 @@ Requires = "1.3.1"
 SNNModels = "1.8"
 Statistics = "1.11"
 UnPack = "1.0"
-julia = "1.11"
+julia = "1.12"


### PR DESCRIPTION
Bump julia compat 1.11 -> 1.12 and patch version 0.2.7 -> 0.2.8. SNNModels >=1.7 requires julia >=1.12 (per registry Compat.toml), so SNNPlots' own julia floor was stale and blocking AutoMerge on the v0.2.7 registration.